### PR TITLE
app/UI: various UI tweaks

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/spf13/cobra"
@@ -13,14 +14,23 @@ var (
 
 func main() {
 	var rootCmd = &cobra.Command{
-		Use:   "gradient-engineer [flags] PLAYBOOK_NAME",
+		Use:   "gradient-engineer [flags] [PLAYBOOK_NAME]",
 		Short: "Run diagnostic playbooks using gradient engineer toolbox",
 		Long: `Gradient Engineer runs diagnostic playbooks by downloading and executing
 toolbox commands. The toolbox is automatically downloaded from the specified
 repository based on your platform (OS and architecture).`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			playbookName := args[0]
+			var playbookName string
+			if len(args) > 0 {
+				playbookName = args[0]
+			} else {
+				if runtime.GOOS == "linux" {
+					playbookName = "60-second-linux"
+				} else {
+					playbookName = "60-second-darwin"
+				}
+			}
 
 			// Create a new toolbox instance
 			tb := NewToolbox(toolboxRepo, playbookName)

--- a/app/ui.go
+++ b/app/ui.go
@@ -461,7 +461,9 @@ func hsvToRGB(h, s, v float64) (uint8, uint8, uint8) {
 func renderGradientHeader(text string, t float64) string {
 	var b strings.Builder
 	for i, ch := range text {
-		progress := math.Mod(float64(i)/100+t*0.07, 1.0)
+		progress := float64(i)/100 + t*-0.07
+		progress += math.Ceil(math.Abs(progress))
+		progress = math.Mod(progress, 1.0)
 		hue := progress * 360.0
 		// lower brightness for less intense colors
 		r, g, c := hsvToRGB(hue, 0.8, 0.5)
@@ -479,7 +481,9 @@ func generateBanner(t float64) string {
 	var b strings.Builder
 	for _, line := range bannerLines {
 		for i, ch := range line {
-			progress := math.Mod(float64(i)/float64(len(line))+t*0.07+0.5, 1.0)
+			progress := float64(i)/float64(len(line)) + t*-0.07 + 0.5
+			progress += math.Ceil(math.Abs(progress))
+			progress = math.Mod(progress, 1.0)
 			hue := progress * 360.0
 			r, g, cc := hsvToRGB(hue, 1.0, 1.0)
 			colorStr := fmt.Sprintf("#%02X%02X%02X", r, g, cc)

--- a/app/ui.go
+++ b/app/ui.go
@@ -196,7 +196,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !m.summarizing && m.summary == "" {
 				// If summarizer is disabled (no API key), skip summarization and show a notice.
 				if m.summarizer == nil || m.summarizer.disabled {
-					m.summaryNotice = "No API key provided; skipping AI summary."
+					m.summaryNotice = "No API key provided; skipping AI summary.\nSet the API key with OPENAI_API_KEY, OPENROUTER_API_KEY, or ANTHROPIC_API_KEY."
 					return m, nil
 				}
 				m.summarizing = true

--- a/app/ui.go
+++ b/app/ui.go
@@ -20,7 +20,7 @@ var (
 	runningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("69"))
 	successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
 	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	footerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Italic(true)
+	footerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("250")).Italic(true)
 )
 
 // commandStatus represents the execution status of a diagnostic command.
@@ -352,7 +352,7 @@ func (m *model) generateContent() string {
 	// Assemble full UI
 	var b strings.Builder
 	b.WriteString(generateBanner(time.Since(m.startTime).Seconds()))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
 	b.WriteString(commandsBox)
 
 	if m.summarizing {
@@ -375,7 +375,7 @@ func (m *model) generateContent() string {
 	}
 
 	b.WriteString("\n\n")
-	b.WriteString(footerStyle.Render("Tab: toggle details   q: quit"))
+	b.WriteString(footerStyle.Render("Tab: toggle details; q: quit; up/down or mouse: scroll"))
 	b.WriteString("\n")
 
 	return b.String()
@@ -392,24 +392,14 @@ func indent(text, prefix string) string {
 
 // ASCII banner lines for Gradient Engineer logo.
 var bannerLines = []string{
-	"                                      ░██ ░██                         ░██     ",
-	"                                      ░██                             ░██     ",
-	" ░████████ ░██░████  ░██████    ░████████ ░██ ░███████  ░████████  ░████████  ",
-	"░██    ░██ ░███           ░██  ░██    ░██ ░██░██    ░██ ░██    ░██    ░██     ",
-	"░██    ░██ ░██       ░███████  ░██    ░██ ░██░█████████ ░██    ░██    ░██     ",
-	"░██   ░███ ░██      ░██   ░██  ░██   ░███ ░██░██        ░██    ░██    ░██     ",
-	" ░█████░██ ░██       ░█████░██  ░█████░██ ░██ ░███████  ░██    ░██     ░████  ",
-	"       ░██                                                                    ",
-	" ░███████                                                                     ",
-	"                                 ░██                                          ",
-	"                                                                              ",
-	" ░███████  ░████████   ░████████ ░██░████████   ░███████   ░███████  ░██░████ ",
-	"░██    ░██ ░██    ░██ ░██    ░██ ░██░██    ░██ ░██    ░██ ░██    ░██ ░███     ",
-	"░█████████ ░██    ░██ ░██    ░██ ░██░██    ░██ ░█████████ ░█████████ ░██      ",
-	"░██        ░██    ░██ ░██   ░███ ░██░██    ░██ ░██        ░██        ░██      ",
-	" ░███████  ░██    ░██  ░█████░██ ░██░██    ░██  ░███████   ░███████  ░██      ",
-	"                             ░██                                              ",
-	"                       ░███████                                               ",
+	"  ▗▄▄▖▗▄▄▖  ▗▄▖ ▗▄▄▄ ▗▄▄▄▖▗▄▄▄▖▗▖  ▗▖▗▄▄▄▖ ",
+	" ▐▌   ▐▌ ▐▌▐▌ ▐▌▐▌  █  █  ▐▌   ▐▛▚▖▐▌  █   ",
+	" ▐▌▝▜▌▐▛▀▚▖▐▛▀▜▌▐▌  █  █  ▐▛▀▀▘▐▌ ▝▜▌  █   ",
+	" ▝▚▄▞▘▐▌ ▐▌▐▌ ▐▌▐▙▄▄▀▗▄█▄▖▐▙▄▄▖▐▌  ▐▌  █   ",
+	" ▗▄▄▄▖▗▖  ▗▖ ▗▄▄▖▗▄▄▄▖▗▖  ▗▖▗▄▄▄▖▗▄▄▄▖▗▄▄▖ ",
+	" ▐▌   ▐▛▚▖▐▌▐▌     █  ▐▛▚▖▐▌▐▌   ▐▌   ▐▌ ▐▌",
+	" ▐▛▀▀▘▐▌ ▝▜▌▐▌▝▜▌  █  ▐▌ ▝▜▌▐▛▀▀▘▐▛▀▀▘▐▛▀▚▖",
+	" ▐▙▄▄▖▐▌  ▐▌▝▚▄▞▘▗▄█▄▖▐▌  ▐▌▐▙▄▄▖▐▙▄▄▖▐▌ ▐▌",
 }
 
 // Convert HSV to RGB (0-360, 0-1, 0-1) output uint8 components.
@@ -441,7 +431,7 @@ func hsvToRGB(h, s, v float64) (uint8, uint8, uint8) {
 func renderGradientHeader(text string, t float64) string {
 	var b strings.Builder
 	for i, ch := range text {
-		progress := math.Mod(float64(i)/100+t*0.1, 1.0)
+		progress := math.Mod(float64(i)/100+t*0.07, 1.0)
 		hue := progress * 360.0
 		// lower brightness for less intense colors
 		r, g, c := hsvToRGB(hue, 0.8, 0.5)
@@ -459,7 +449,7 @@ func generateBanner(t float64) string {
 	var b strings.Builder
 	for _, line := range bannerLines {
 		for i, ch := range line {
-			progress := math.Mod(float64(i)/float64(len(line))+t*0.10+0.5, 1.0)
+			progress := math.Mod(float64(i)/float64(len(line))+t*0.07+0.5, 1.0)
 			hue := progress * 360.0
 			r, g, cc := hsvToRGB(hue, 1.0, 1.0)
 			colorStr := fmt.Sprintf("#%02X%02X%02X", r, g, cc)

--- a/app/ui.go
+++ b/app/ui.go
@@ -21,6 +21,7 @@ var (
 	successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
 	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
 	footerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("250")).Italic(true)
+	descStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 )
 
 // commandStatus represents the execution status of a diagnostic command.
@@ -318,7 +319,16 @@ func (m *model) generateContent() string {
 		default:
 			lineStyle = pendingStyle
 		}
-		cmdBuf.WriteString(lineStyle.Render(fmt.Sprintf("%s %s", icon, cmd.Display)))
+		// Render command and lighter description
+		cmdText := cmd.Command
+		if cmd.Spec != nil && strings.TrimSpace(cmd.Spec.Command) != "" {
+			cmdText = cmd.Spec.Command
+		}
+		line := lineStyle.Render(fmt.Sprintf("%s %s", icon, cmdText))
+		if strings.TrimSpace(cmd.Display) != "" {
+			line += " " + descStyle.Render("— "+cmd.Display)
+		}
+		cmdBuf.WriteString(line)
 		cmdBuf.WriteString("\n")
 
 		if m.showDetails {

--- a/playbook/60-second-darwin.yaml
+++ b/playbook/60-second-darwin.yaml
@@ -12,24 +12,24 @@ system_prompt: |
   When recommending actions, prioritize practical steps.
 commands:
   - command: uptime
-    description: System uptime and load averages
+    description: System uptime, load averages
   - command: log show --style syslog --last 1m
-    description: Recent system log entries (last 1 minute)
+    description: Recent system log entries
   - command: vm_stat 1
-    description: Virtual memory paging, 1s updates
+    description: Virtual memory paging
   - command: ps -M -o pid,%cpu,comm -r
-    description: Threads sorted by CPU to spot hot single-thread bottlenecks
+    description: Threads sorted by CPU
   - command: top -l 999 -s 1 -o cpu
-    description: Per-process CPU usage, 1s rolling view
+    description: Per-process CPU usage
   - command: iostat -d -w 1
-    description: Disk I/O per device, 1s updates (KB/t, tps, MB/s)
+    description: Disk I/O per device
   - command: memory_pressure -Q
-    description: Memory pressure summary (free, purgeable, compressed)
+    description: Memory pressure summary
   - command: netstat -w 1 -i
-    description: Network device statistics for all interfaces, 1s updates
+    description: Network device statistics
   - command: netstat -s -p tcp
-    description: TCP health snapshot (retransmits, connection stats)
+    description: TCP health snapshot
   - command: top -l 1
-    description: One-shot system snapshot (CPU breakdown, processes, PhysMem)
+    description: Top processes snapshot
 
 

--- a/playbook/60-second-linux.yaml
+++ b/playbook/60-second-linux.yaml
@@ -19,21 +19,21 @@ system_prompt: |
   When recommending actions, prioritize practical steps.
 commands:
   - command: uptime
-    description: System uptime and load averages
+    description: System uptime, load averages
   - command: vmstat 1
-    description: Virtual memory statistics, 1s updates
+    description: Virtual memory statistics
   - command: mpstat -P ALL 1
-    description: CPU utilization per core, 1s
+    description: CPU utilization per core
   - command: pidstat 1
-    description: Per-process CPU usage, 1s
+    description: Per-process CPU usage
   - command: iostat -xz 1
-    description: Extended I/O statistics, 1s
+    description: Extended I/O statistics
   - command: free -m
-    description: Memory usage in MiB
+    description: Memory usage
   - command: sar -n DEV 1
-    description: Network device statistics, 1s
+    description: Network device statistics
   - command: sar -n TCP,ETCP 1
-    description: TCP counters and errors, 1s
+    description: TCP counters and errors
   - command: top -b -n 1
     description: Top processes snapshot
   - command: dmesg


### PR DESCRIPTION
- Show more descriptive error when API key not set (list missing env vars)
- Make `PLAYBOOK_NAME` optional (default to `60-second-linux` / `60-second-darwin`)
- UI: display both command and description with shorter text
- UI: footer + banner tweaks, lighter colors, slower gradient
- UI: improved command execution feedback (scrolling, spinner, finished message)
- UI: adjust gradient direction (move right instead of left)