### PR TITLE
playbook: store playbook name in YAML

### DIFF
--- a/app/ui.go
+++ b/app/ui.go
@@ -364,14 +364,25 @@ func (m *model) generateContent() string {
 	cmdBuf.WriteString(cmdStr)
 
 	// Border the commands with a title (plain header, with spinner while running or a tick when finished)
-	headerTitle := titleStyle.Render("60-second Linux analysis")
 	var header string
-	if m.execSeconds == 0 {
-		header = fmt.Sprintf("%s %s", m.spin.View(), headerTitle)
-	} else {
-		header = fmt.Sprintf("%s %s %s", successStyle.Render(iconSuccess), headerTitle, descStyle.Render(fmt.Sprintf("(finished in %.1f seconds)", m.execSeconds)))
+	title := ""
+	if m.toolbox != nil && m.toolbox.Playbook != nil && strings.TrimSpace(m.toolbox.Playbook.Name) != "" {
+		title = m.toolbox.Playbook.Name
 	}
-	commandsBox := header + "\n\n" + cmdBuf.String()
+	if title != "" {
+		headerTitle := titleStyle.Render(title)
+		if m.execSeconds == 0 {
+			header = fmt.Sprintf("%s %s", m.spin.View(), headerTitle)
+		} else {
+			header = fmt.Sprintf("%s %s %s", successStyle.Render(iconSuccess), headerTitle, descStyle.Render(fmt.Sprintf("(finished in %.1f seconds)", m.execSeconds)))
+		}
+	}
+	var commandsBox string
+	if header != "" {
+		commandsBox = header + "\n\n" + cmdBuf.String()
+	} else {
+		commandsBox = cmdBuf.String()
+	}
 
 	// Assemble full UI
 	var b strings.Builder

--- a/playbook/60-second-darwin.yaml
+++ b/playbook/60-second-darwin.yaml
@@ -1,4 +1,5 @@
 id: 60-second-darwin
+name: 60-second macOS analysis
 system_prompt: |
   ### 60-second macOS analysis
 

--- a/playbook/60-second-linux.yaml
+++ b/playbook/60-second-linux.yaml
@@ -1,4 +1,5 @@
 id: 60-second-linux
+name: 60-second Linux analysis
 nixpkgs:
   version: "380be19fbd2d9079f677978361792cb25e8a3635" # nixos-22.05 branch
   packages:

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -2,6 +2,7 @@ package playbook
 
 type PlaybookConfig struct {
 	ID      string `yaml:"id"`
+	Name    string `yaml:"name,omitempty"`
 	Nixpkgs struct {
 		Version  string   `yaml:"version"`
 		Packages []string `yaml:"packages"`


### PR DESCRIPTION
Previously, we always printed "60-second Linux analysis", even for macOS. Now, the title of the playbook is stored in the YAML file and it used in UI.